### PR TITLE
Use ligolw_add from python-ligo-lw

### DIFF
--- a/bin/omicron-process
+++ b/bin/omicron-process
@@ -829,7 +829,7 @@ for s, e in segs:
                     else:
                         xml = os.path.join(chandir,
                                            filename.replace('root', 'xml'))
-                        operations.append('%s %s --output %s'
+                        operations.append('%s %s --ilwdchar-compat --output %s'
                                           % (ligolw_add, xmlfiles, xml))
                         rmfiles.append(xmlfiles)
                         ppnode._CondorDAGNode__output_files.append(xml)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ numpy
 pyOpenSSL
 pykerberos
 lscsoft-glue >= 1.60.0
+python-ligo-lw >= 1.4.0
 ligo-segments
 lalsuite
 dqsegdb

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ install_requires = [
     'lalsuite',
     'dqsegdb',
     'gwpy',
+    'python-ligo-lw >= 1.4.0',
 ]
 tests_require = [
     'pytest',


### PR DESCRIPTION
This PR updates `omicron-process` to use the `--ilwdchar-compat` flag for `ligolw_add` as provided by `python-ligo-lw`.