### PR TITLE
Upgrade to gwdatafind for GWF discovery

### DIFF
--- a/bin/omicron-print
+++ b/bin/omicron-print
@@ -31,15 +31,13 @@ from tokenize import generate_tokens
 from StringIO import StringIO
 
 import numpy
-from numpy.lib import recfunctions
 
-from glue.lal import Cache
-
-from gwpy.table.lsctables import SnglBurstTable
+from gwpy.table import EventTable
+from gwpy.table.filters import in_segmentlist
 from gwpy.time import to_gps
 
 from omicron import (io, const, __version__)
-from omicron.segments import (Segment, SegmentList)
+from omicron.segments import (Segment, SegmentList, cache_segments)
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
@@ -134,7 +132,8 @@ fopts.add_argument('-g', '--gaps', action='store_true', default=False,
                         'exitcode as follows: 0, no gaps found; '
                         '1, some files found with gaps')
 fopts.add_argument('-t', '--file-type', default='xml.gz',
-                   choices=['root', 'xml.gz'], help='type of files to find')
+                   choices=['root', 'xml.gz', 'h5'],
+                   help='type of files to find')
 
 # -- print files
 fparser = parsers.add_parser(
@@ -171,22 +170,18 @@ start = int(args.gpsstart)
 end = int(args.gpsend)
 gaps = args.gaps
 
-# set default columns
-if not args.column:
-    args.column = ['time', 'peak_frequency', 'snr']
-
 # -- find files ---------------------------------------------------------------
 
 # build segment list (placeholder for allowing custom states, perhaps)
 segs = SegmentList([Segment(start, end)])
 
-cache = Cache()
+cache = []
 for seg in segs:
     cache.extend(io.find_omicron_files(
         args.channel, start, end, args.base_directory, ext=args.file_type))
 
 # find gaps
-known = cache.to_segmentlistdict()[args.channel.split(':')[0]] & segs
+known = cache_segments(cache) & segs
 if gaps:
     gaps = segs - known
 if not known:
@@ -200,58 +195,45 @@ elif gaps:
 
 if args.mode == 'files':
     if args.lal_cache:
-        cache.tofile(sys.stdout)
+        write_cache(cache, sys.stdout)
     else:
-        cache.topfnfile(sys.stdout)
+        for path in cache:
+            print(path)
     if gaps:
         sys.exit(1)
-    else:
-        sys.exit(0)
+    sys.exit(0)
 
 
 # -- read events --------------------------------------------------------------
 
-# build filt based on conditions
-def filter_events(array):
-    """Returns `True` if we should keep this event
-    """
-    keep = numpy.ones(array.shape[0], dtype=bool)
-    # filter on segments
-    for seg in segs:
-        keep &= array['time'] >= seg[0]
-        keep &= array['time'] < seg[1]
-    # apply user conditions
-    for col, math in args.condition:
-        vals = array[col]
-        for l, op in math:
-            keep &= op(vals, l)
-    return keep
-
+# set default columns
+if not args.column and args.file_type == 'xml.gz':
+    args.column = ['peak', 'peak_frequency', 'snr']
+elif not args.column:
+    args.column = ['time', 'frequency', 'snr']
 
 # read events (with simple filter on segments)
 if args.file_type == 'xml.gz':
     cname = args.channel.split(':', 1)[1]
-    table = SnglBurstTable.read(cache, filt=lambda x: x.channel == cname)
+    events = EventTable.read(cache, format='ligolw', tablename='sngl_burst',
+                             selection=[('peak', in_segmentlist, segs),
+                                        'channel == "{0}"'.format(cname)],
+                             columns=set(args.column + ['peak', 'channel']))
+elif args.file_type == 'root':
+    events = EventTable.read(cache, format='root', treename='triggers',
+                             selection=('time', in_segmentlist, segs),
+                             columns=set(args.column + ['time']))
 else:
-    table = SnglBurstTable.read(cache)
-events = table.to_recarray()
-
-# inject time column into recarray
-if 'time' not in events.dtype.names:
-    times = events['peak_time'] + events['peak_time_ns'] * 1e-9
-    events = recfunctions.rec_append_fields(events, 'time', times, times.dtype)
-
-# apply conditions
-events = events[filter_events(events)]
+    full = EventTable.read(cache, format='hdf5', path='triggers')
+    events = full.filter(('time', in_segmentlist, segs))[args.column]
 
 # sort events
 if args.rank_by:
-    events.sort(order=args.rank_by)
+    events.sort(args.rank_by)
     if not args.reverse_rank:
         events = events[::-1]
 
 # print events
 print("#%s" % args.delimiter.join(args.column))
 for e in events[:args.max_events]:
-    print(args.delimiter.join(['%%%s' % e[col].dtype.kind % e[col]
-                               for col in args.column]))
+    print(args.delimiter.join(map(str, (e[col] for col in args.column))))

--- a/bin/omicron-process
+++ b/bin/omicron-process
@@ -81,7 +81,8 @@ except ImportError:
 import htcondor
 
 from glue import pipeline
-from glue.lal import (Cache, CacheEntry)
+
+from gwpy.io.cache import read_cache
 
 from omicron import (const, segments, log, data, parameters, utils, condor, io,
                      __version__)
@@ -604,8 +605,7 @@ dataspan = type(segs)([segments.Segment(datastart, dataend)])
 # -- find the frames
 # find frames under /dev/shm (which creates a cache of temporary files)
 if args.cache_file:
-    with open(args.cache_file, 'r') as fobj:
-        cache = Cache.fromfile(fobj)
+    cache = read_cache(args.cache_file)
 elif args.use_dev_shm and len(segs):  # only cache if we have state segments
     cache = data.find_frames(ifo, frametype, datastart, dataend,
                              on_gaps='warn', tmpdir=cachedir)
@@ -923,7 +923,7 @@ if omicronv >= 'v2r2':
 # do all archiving last, once all post-processing has completed
 if args.archive:
     archivenode = pipeline.CondorDAGNode(archivejob)
-    acache = {fmt: Cache() for fmt in fileformats}
+    acache = {fmt: list() for fmt in fileformats}
     if newdag:
         # write shell script to seed archive
         with open(archivejob.get_executable(), 'w') as f:
@@ -946,8 +946,8 @@ if args.archive:
                         'txt': '.txt',
                 }.items():
                     try:
-                        acache[fmt].extend(map(CacheEntry.from_T050017, filter(
-                            lambda x: x.endswith(extensions), filenames)))
+                        acache[fmt].extend(filter(
+                            lambda x: x.endswith(extensions), filenames))
                     except KeyError:  # file format not used
                         continue
         os.chmod(archivejob.get_executable(), 0o755)

--- a/bin/omicron-status
+++ b/bin/omicron-status
@@ -49,6 +49,7 @@ import h5py
 
 from glue import markup
 
+from gwpy.io.cache import sieve as sieve_cache
 from gwpy.time import to_gps
 from gwpy.segments import (Segment, SegmentList)
 from gwpy.plotter import (TimeSeriesPlot, SegmentAxes)
@@ -447,8 +448,8 @@ for c in channels:
     for y, ft in enumerate(filetypes):
         # find files
         cache = io.find_omicron_files(c, start, end, archive, ext=ft)
-        cpend = io.find_pending_files(c, proddir, ext=ft).sieve(
-            segment=Segment(start, end))
+        cpend = sieve_cache(io.find_pending_files(c, proddir, ext=ft),
+                            segment=Segment(start, end))
         # get available segments
         found = segments.cache_segments(cache) & segs
         pending[c][ft] = segments.cache_segments(cpend) & segs

--- a/omicron/nagios.py
+++ b/omicron/nagios.py
@@ -27,8 +27,6 @@ from getpass import getuser
 
 import htcondor
 
-from glue.lal import CacheEntry
-
 from . import (const, condor)
 from .io import find_latest_omicron_file
 from .data import get_latest_data_gps
@@ -185,6 +183,6 @@ def find_archive_latency(channel, padding, frametype=None, state=None,
     latency = {}
     for ext in ['root', 'xml.gz']:
         f = find_latest_omicron_file(channel, base, ext=ext)
-        e = CacheEntry.from_T050017(f)
-        latency[ext] = (int(target - e.segment[1]), f)
+        end = file_segment(f)[1]
+        latency[ext] = (int(target - end), f)
     return latency

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ dqsegdb
 gwpy
 htcondor
 h5py
+gwdatafind

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ install_requires = [
     'gwpy',
     'python-ligo-lw >= 1.4.0',
     'h5py',
+    'gwdatafind',
 ]
 tests_require = [
     'pytest',


### PR DESCRIPTION
This PR updates `pyomicron` to use `gwdatafind` for GWF discovery.

This API returns simple file paths, so included are modifications to everything needed to just use these paths` rather than the `glue.lal.Cache` or `lal.utils.CacheEntry` objects.

I also updated `omicron-print` to support modern versions of `gwpy`, and HDF5.