### PR TITLE
Use dqsegdb2 for getting flag availability

### DIFF
--- a/omicron/segments.py
+++ b/omicron/segments.py
@@ -32,7 +32,7 @@ from glue.lal import Cache
 from glue.segmentsUtils import fromsegwizard
 from ligo.segments import (segmentlist as SegmentList, segment as Segment)
 
-from dqsegdb.urifunctions import getDataUrllib2 as dqsegdb_uri_query
+from dqsegdb2.http import request as dqsegdb2_request
 
 from gwpy.io.cache import cache_segments as _cache_segments
 from gwpy.segments import DataQualityFlag
@@ -167,8 +167,8 @@ def get_flag_coverage(flag, url='https://segments.ligo.org'):
     """
     ifo, name, version = flag.rsplit(':', 2)
     flagu = '/dq/%s/%s/%s' % (ifo, name, version)
-    raw = dqsegdb_uri_query('%s/report/coverage' % url)
-    return json.loads(raw)['results'][flagu]
+    raw = dqsegdb2_request('%s/report/coverage' % url)
+    return json.loads(raw.read().decode('utf-8'))['results'][flagu]
 
 
 def get_latest_active_gps(flag, url='https://segments.ligo.org'):

--- a/omicron/segments.py
+++ b/omicron/segments.py
@@ -32,6 +32,7 @@ from glue.lal import Cache
 from glue.segmentsUtils import fromsegwizard
 from ligo.segments import (segmentlist as SegmentList, segment as Segment)
 
+from dqsegdb2.query import DEFAULT_SEGMENT_SERVER
 from dqsegdb2.http import request as dqsegdb2_request
 
 from gwpy.io.cache import cache_segments as _cache_segments
@@ -162,7 +163,7 @@ def segmentlist_from_tree(tree, coalesce=False):
     return segs
 
 
-def get_flag_coverage(flag, url='https://segments.ligo.org'):
+def get_flag_coverage(flag, url=DEFAULT_SEGMENT_SERVER):
     """Return the coverage data for the given flag
     """
     ifo, name, version = flag.rsplit(':', 2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ lscsoft-glue >= 1.60.0
 python-ligo-lw >= 1.4.0
 ligo-segments
 lalsuite
-dqsegdb
+dqsegdb2
 gwpy
 htcondor
 h5py

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ install_requires = [
     'ligo-segments',
     'htcondor',
     'lalsuite',
-    'dqsegdb',
+    'dqsegdb2',
     'gwpy',
     'python-ligo-lw >= 1.4.0',
     'h5py',


### PR DESCRIPTION
This PR updates `omicron.segments` to use the `dqsegdb2` library to query a LIGO-Virgo segment database for flag information. This library is much lighter than `dqsegdb`, and works on python3.