### PR TITLE
Move to pytest for all syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
 
 before_install:
   - python -m pip install ${PIP_FLAGS} --upgrade pip
-  - python -m pip install ${PIP_FLAGS} "pytest>=2.8" pytest-cov unittest2
+  - python -m pip install ${PIP_FLAGS} "pytest>=2.8" pytest-cov
   - python -m pip install ${PIP_FLAGS} -r requirements.txt
 
 install:

--- a/omicron/tests/__init__.py
+++ b/omicron/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) Duncan Macleod (2016)
+# Copyright (C) Duncan Macleod (2018)
 #
 # This file is part of PyOmicron.
 #
@@ -16,17 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with PyOmicron.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Python-version compatibility utils for Omicron tests
+"""Tests for PyOmicron
 """
 
-import sys
-
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+__author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'

--- a/omicron/tests/mock_htcondor.py
+++ b/omicron/tests/mock_htcondor.py
@@ -7,10 +7,10 @@
 class Schedd(object):
     """Mock of the `htcondor.Schedd` object
     """
-
     _jobs = []
 
     def query(self, constraints, attr_list=[], **kwargs):
+        print('_jobs', self._jobs)
         x = {}
         for con in constraints.split(' && '):
             try:
@@ -20,8 +20,8 @@ class Schedd(object):
             else:
                 x[a] = eval(b)
         match = []
+        print(x)
         def match(job):
-            print(job, x)
             for key in x:
                 if x[key] != job[key]:
                     return False

--- a/omicron/tests/test_io.py
+++ b/omicron/tests/test_io.py
@@ -19,20 +19,15 @@
 """Tests for omicron.io
 """
 
-from compat import unittest
-
-from omicron import (io, const)
+from .. import (io, const)
 
 
-class IoTestCase(unittest.TestCase):
-    def test_get_archive_filename(self):
-        self.assertEqual(
-            io.get_archive_filename('L1:GDS-CALIB_STRAIN', 0, 100),
-            '%s/L1/GDS_CALIB_STRAIN_OMICRON/00000/'
-            'L1-GDS_CALIB_STRAIN_OMICRON-0-100.xml.gz' % const.OMICRON_ARCHIVE)
-        self.assertEqual(
-            io.get_archive_filename('L1:GDS-CALIB_STRAIN', 1234567890, 123,
-                                    archive='/triggers', filetag='TEST-TAg',
-                                    ext='root'),
-            '/triggers/L1/GDS_CALIB_STRAIN_TEST_TAg/12345/'
-            'L1-GDS_CALIB_STRAIN_TEST_TAg-1234567890-123.root')
+def test_get_archive_filename():
+    assert io.get_archive_filename('L1:GDS-CALIB_STRAIN', 0, 100) == (
+        '%s/L1/GDS_CALIB_STRAIN_OMICRON/00000/'
+        'L1-GDS_CALIB_STRAIN_OMICRON-0-100.xml.gz' % const.OMICRON_ARCHIVE)
+    assert io.get_archive_filename(
+            'L1:GDS-CALIB_STRAIN', 1234567890, 123, archive='/triggers',
+            filetag='TEST-TAg', ext='root') == (
+        '/triggers/L1/GDS_CALIB_STRAIN_TEST_TAg/12345/'
+        'L1-GDS_CALIB_STRAIN_TEST_TAg-1234567890-123.root')

--- a/omicron/tests/test_log.py
+++ b/omicron/tests/test_log.py
@@ -19,30 +19,31 @@
 """Test logging for Omicron
 """
 
-import unittest
+import re
 
-from omicron import log
+from .. import log
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 
-class LogTestCase(unittest.TestCase):
+def test_bold():
+    assert log.bold('TEST') == '\x1b[1mTEST\x1b[0m'
 
-    def test_bold(self):
-        self.assertEqual(log.bold('TEST'), '\x1b[1mTEST\x1b[0m')
 
-    def test_color_text(self):
-        self.assertEqual(log.color_text('TEST', 'blue'),
-                         '\x1b[1;34mTEST\x1b[0m')
+def test_color_text():
+    assert log.color_text('TEST', 'blue') == '\x1b[1;34mTEST\x1b[0m'
 
-    def test_logger(self):
-        # create logger
-        logger = log.Logger('TEST')
-        # fudge a record
-        record = logger.makeRecord(logger.name, log.logging.DEBUG, 'FILE', 0,
-                                   'test message', (), None, 'FUNC', None)
-        # test that the formatter prints the correct thing
-        outhandler = logger.handlers[0]
-        self.assertRegexpMatches(outhandler.format(record),
-                                 '\[\\x1b\[1mTEST\\x1b\[0m \d+\]    '
-                                 '\\x1b\[1;34mDEBUG\\x1b\[0m: test message')
+
+def test_logger():
+    # create logger
+    logger = log.Logger('TEST')
+
+    # fudge a record
+    record = logger.makeRecord(logger.name, log.logging.DEBUG, 'FILE', 0,
+                               'test message', (), None, 'FUNC', None)
+
+    # test that the formatter prints the correct thing
+    outhandler = logger.handlers[0]
+    assert re.match(r'\[\x1b\[1mTEST\x1b\[0m \d+\]    '
+                    r'\x1b\[1;34mDEBUG\x1b\[0m: test message',
+                    outhandler.format(record))

--- a/omicron/tests/test_nagios.py
+++ b/omicron/tests/test_nagios.py
@@ -19,9 +19,7 @@
 """Test logging for Omicron
 """
 
-import unittest
-
-from omicron import nagios
+from .. import nagios
 
 __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 

--- a/omicron/tests/test_utils.py
+++ b/omicron/tests/test_utils.py
@@ -21,24 +21,23 @@
 
 import os
 
-from compat import unittest
-
-from omicron import utils
+from .. import utils
 
 
-class UtilsTestCase(unittest.TestCase):
-    def test_get_omicron_version(self):
-        testv = 'v2r1'
-        v = utils.get_omicron_version(
-            "/home/detchar/opt/virgosoft/Omicron/%s/Linux-x86_64/omicron.exe"
-            % testv
-        )
-        self.assertEqual(v, testv)
-        os.environ['OMICRON_VERSION'] = testv
-        self.assertEqual(utils.get_omicron_version(), testv)
-        os.environ.pop('OMICRON_VERSION')
-        os.environ['OMICRONROOT'] = (
-            "/home/detchar/opt/virgosoft/Omicron/%s" % testv)
-        self.assertEqual(utils.get_omicron_version(), testv)
-        self.assertGreater(utils.get_omicron_version(), 'v1r2')
-        self.assertLess(utils.get_omicron_version(), 'v2r2')
+def test_get_omicron_version():
+    testv = 'v2r1'
+    v = utils.get_omicron_version(
+        "/home/detchar/opt/virgosoft/Omicron/%s/Linux-x86_64/omicron.exe"
+        % testv
+    )
+    assert v == testv
+
+    os.environ['OMICRON_VERSION'] = testv
+    assert utils.get_omicron_version() == testv
+
+    os.environ.pop('OMICRON_VERSION')
+    os.environ['OMICRONROOT'] = (
+        "/home/detchar/opt/virgosoft/Omicron/%s" % testv)
+    assert utils.get_omicron_version() == testv
+    assert utils.get_omicron_version() > 'v1r2'
+    assert utils.get_omicron_version() < 'v2r2'

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ gwpy
 htcondor
 h5py
 gwdatafind
+pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,9 +4,6 @@ license_file = COPYING
 [aliases]
 test = pytest
 
-[tool:pytest]
-addopts = --verbose --exitfirst -r s
-
 [versioneer]
 VCS = git
 style = pep440


### PR DESCRIPTION
This PR modifies the `omicron.tests` test suite to use `pytest` for all testing syntax, rather than `unittest`.