### PR TITLE
Read acknowledged segments as float

### DIFF
--- a/bin/omicron-status
+++ b/bin/omicron-status
@@ -400,7 +400,7 @@ else:
 # load acknowledged gaps
 acksegfile = os.path.join(outdir, 'acknowledged-gaps-%s.txt' % tag)
 try:
-    acknowledged = SegmentList.read(acksegfile)
+    acknowledged = SegmentList.read(acksegfile, gpstype=float)
 except IOError:  # no file
     acknowledged = SegmentList()
 else:


### PR DESCRIPTION
This PR fixes an issue with serialising the `gaps` segments to JSON in `omicron-status` by reading the 'acknowledged' segment list with `gpstype=float`.