### PR TITLE
Added data_segments function to parse available data segments from GWF

### DIFF
--- a/omicron/segments.py
+++ b/omicron/segments.py
@@ -31,7 +31,7 @@ from dqsegdb2.query import DEFAULT_SEGMENT_SERVER
 from dqsegdb2.http import request as dqsegdb2_request
 
 from gwpy.io.cache import (cache_segments as _cache_segments, file_segment)
-from gwpy.io.gwf import open_gwf
+from gwpy.io.gwf import data_segments as gwf_data_segments
 from gwpy.segments import (DataQualityFlag, Segment, SegmentList)
 from gwpy.timeseries import (StateTimeSeries, StateVector, TimeSeriesDict)
 from gwpy.time import LIGOTimeGPS
@@ -163,7 +163,7 @@ def get_state_segments(channel, frametype, start, end, bits=[0], nproc=1,
 
     # Virgo drops the state vector regularly, so need to sieve the files
     if channel == "V1:DQ_ANALYSIS_STATE_VECTOR":
-        span = data_segments(cache, channel)
+        span = gwf_data_segments(cache, channel)
     else:
         span = SegmentList([Segment(pstart, pend)])
 
@@ -301,38 +301,3 @@ def cache_overlaps(*caches):
             overlap.extend(ol)
         segments.append(seg)
     return overlap
-
-
-def data_segments(cache, channel):
-    segments = SegmentList()
-    for path in cache:
-        segments.extend(_gwf_channel_segments(path, channel))
-    return segments.coalesce()
-
-
-def _gwf_channel_segments(path, channel):
-    """Yields the segments containing data for ``channel`` in this GWF path
-    """
-    stream = open_gwf(path)
-    # get segments for frames
-    toc = stream.GetTOC()
-    secs = toc.GetGTimeS()
-    nano = toc.GetGTimeN()
-    dur = toc.GetDt()
-
-    readers = [getattr(stream, 'ReadFr{0}Data'.format(type_.title())) for
-               type_ in ("proc", "sim", "adc")]
-
-    # for each segment, try and read the data for this channel
-    for i, (s, ns, dt) in enumerate(zip(secs, nano, dur)):
-        for read in readers:
-            try:
-                read(i, channel)
-            except IndexError:
-                continue
-            readers = [read]  # use this one from now on
-            epoch = LIGOTimeGPS(s, ns)
-            yield Segment(epoch, epoch + dt)
-            break
-        else:  # none of the readers worked for this channel, warn
-            warnings.warn("{0!r} not found in {1}".format(channel, path))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 dqsegdb2
 gwdatafind
-gwpy >=0.14.0
+gwpy >=0.14.1
 h5py
 htcondor
 ligo-segments

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup_requires = [
 install_requires = [
     'dqsegdb2',
     'gwdatafind',
-    'gwpy >= 0.14.0',
+    'gwpy >= 0.14.1',
     'h5py',
     'htcondor',
     'ligo-segments',


### PR DESCRIPTION
This PR adds `omicron.segments.data_segments()` which determines those segments that could yield data, without parsing the data themselves. This is mainly to overcome the problems at Virgo whereby the state vector channel isn't guaranteed to be in the frames at all.