### PR TITLE
Updated references to lscsoft-glue

### DIFF
--- a/bin/omicron-status
+++ b/bin/omicron-status
@@ -47,7 +47,7 @@ from matplotlib.gridspec import GridSpec
 
 import h5py
 
-from glue import markup
+from MarkupPy import markup
 
 from gwpy.io.cache import sieve as sieve_cache
 from gwpy.time import to_gps

--- a/omicron/segments.py
+++ b/omicron/segments.py
@@ -26,8 +26,6 @@ import re
 from math import (floor, ceil)
 from functools import wraps
 
-from glue.lal import Cache
-
 from dqsegdb2.query import DEFAULT_SEGMENT_SERVER
 from dqsegdb2.http import request as dqsegdb2_request
 
@@ -284,7 +282,7 @@ def get_latest_known_gps(flag, url=DEFAULT_SEGMENT_SERVER):
 def cache_overlaps(*caches):
     """Find segments of overlap in the given cache sets
     """
-    cache = Cache(e for c in caches for e in c)
+    cache = [e for c in caches for e in c]
     cache.sort(key=lambda e: file_segment(e)[0])
     overlap = SegmentList()
     segments = SegmentList()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ pykerberos
 lscsoft-glue >= 1.60.0
 python-ligo-lw >= 1.4.0
 ligo-segments
-lalsuite
 dqsegdb2
 gwpy >=0.14.0
 htcondor

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ htcondor
 h5py
 gwdatafind
 pytest
+MarkupPy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,12 @@
-six
-numpy
-pyOpenSSL
-pykerberos
-lscsoft-glue >= 1.60.0
-python-ligo-lw >= 1.4.0
-ligo-segments
 dqsegdb2
-gwpy >=0.14.0
-htcondor
-h5py
 gwdatafind
-pytest
+gwpy >=0.14.0
+h5py
+htcondor
+ligo-segments
+lscsoft-glue >= 1.60.0
 MarkupPy
+numpy
+python-ligo-lw >= 1.4.0
+six
+pytest

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ install_requires = [
     'python-ligo-lw >= 1.4.0',
     'h5py',
     'gwdatafind',
+    'MarkupPy',
 ]
 tests_require = [
     'pytest',

--- a/setup.py
+++ b/setup.py
@@ -48,17 +48,17 @@ setup_requires = [
     'setuptools',
 ]
 install_requires = [
-    'six',
-    'numpy',
-    'lscsoft-glue >= 1.60.0',
-    'ligo-segments',
-    'htcondor',
     'dqsegdb2',
-    'gwpy >= 0.14.0',
-    'python-ligo-lw >= 1.4.0',
-    'h5py',
     'gwdatafind',
+    'gwpy >= 0.14.0',
+    'h5py',
+    'htcondor',
+    'ligo-segments',
+    'lscsoft-glue >= 1.60.0',
     'MarkupPy',
+    'numpy',
+    'python-ligo-lw >= 1.4.0',
+    'six',
 ]
 tests_require = [
     'pytest',

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ install_requires = [
     'lscsoft-glue >= 1.60.0',
     'ligo-segments',
     'htcondor',
-    'lalsuite',
     'dqsegdb2',
     'gwpy >= 0.14.0',
     'python-ligo-lw >= 1.4.0',


### PR DESCRIPTION
This PR removes a couple of references to glue, such that the only remaining requirement is `glue.pipeline`, which doesn't require lalsuite (which is nice).