### PR TITLE
Fixed a few python3 compatibility issues

### DIFF
--- a/bin/omicron-process
+++ b/bin/omicron-process
@@ -275,7 +275,7 @@ online = args.gps is None
 # format file-tag as underscore-delimited upper-case string
 filetag = args.file_tag
 if filetag:
-    filetag = re.sub('[:_\s-]', '_', filetag).rstrip('_').strip('_')
+    filetag = re.sub(r'[:_\s-]', '_', filetag).rstrip('_').strip('_')
     if const.OMICRON_FILETAG.lower() in filetag.lower():
         afiletag = filetag
     else:

--- a/omicron/io.py
+++ b/omicron/io.py
@@ -33,7 +33,7 @@ from gwpy.time import tconvert
 from . import const
 from .segments import (Segment, segmentlist_from_tree)
 
-re_delim = re.compile('[:_-]')
+re_delim = re.compile(r'[:_-]')
 
 
 def merge_root_files(inputfiles, outputfile,

--- a/omicron/parameters.py
+++ b/omicron/parameters.py
@@ -38,7 +38,7 @@ from collections import OrderedDict
 from . import (const, utils)
 from .segments import integer_segments
 
-CHANNEL_DELIM_REGEX = re.compile('[:_-]')
+CHANNEL_DELIM_REGEX = re.compile(r'[:_-]')
 UNUSED_PARAMS = ['state-flag', 'frametype', 'state-channel', 'state-frametype']
 OMICRON_PARAM_MAP = {
     'sample-frequency': ('DATA', 'SAMPLEFREQUENCY')

--- a/omicron/parameters.py
+++ b/omicron/parameters.py
@@ -105,7 +105,7 @@ class OmicronParameters(configparser.ConfigParser):
         return raw.split()
 
     def getfloats(self, section, option):
-        return map(float, self.getlist(section, option))
+        return list(map(float, self.getlist(section, option)))
 
     def optionxform(self, optionstr):
         return optionstr.upper()

--- a/omicron/segments.py
+++ b/omicron/segments.py
@@ -90,7 +90,7 @@ STATE_CHANNEL = {
         "V1_llhoft",
     ),
 }
-RAW_TYPE_REGEX = re.compile('[A-Z]1_R')
+RAW_TYPE_REGEX = re.compile(r'[A-Z]1_R')
 
 
 def integer_segments(f):


### PR DESCRIPTION
This PR fixes some python3 issues, mainly using r-strings for regular expressions, and casting `map()` to `list`.