### PR TITLE
Use FQDN regular expression to set default IFO

### DIFF
--- a/omicron/const.py
+++ b/omicron/const.py
@@ -20,9 +20,19 @@
 """
 
 import os
+import re
 from pathlib import Path
 
 from ligo.segments import segment as Segment
+
+IFO_FQDN_REGEX = {
+    "G1": re.compile(r"\.uni-hannover"),
+    "H1": re.compile(r"\.ligo-wa"),
+    "K1": re.compile(r"\.kagra"),
+    "L1": re.compile(r"\.ligo-la"),
+    "V1": re.compile(r"\.(virgo|ego-gw)"),
+}
+
 
 # -- generic parameters
 try:
@@ -30,17 +40,13 @@ try:
 except KeyError:
     from socket import getfqdn
     fqdn = getfqdn()
-    if '.uni-hannover.' in fqdn:
-        IFO = 'G1'
-    elif '.ligo-wa.' in fqdn:
-        IFO = 'H1'
-    elif '.ligo-la.' in fqdn:
-        IFO = 'L1'
-    elif '.virgo.' in fqdn or '.ego-gw.' in fqdn:
-        IFO = 'V1'
+    for _key, _regex in IFO_FQDN_REGEX.items():
+        if _regex.search(fqdn):
+            IFO = _key.upper()
+            break
     else:
         IFO = None
-    ifo = os.getenv('ifo')
+    ifo = os.getenv('ifo', IFO.lower() if IFO else None)
 else:
     ifo = os.getenv('ifo', IFO.lower())
 SITE = os.getenv('SITE')

--- a/omicron/tests/test_condor.py
+++ b/omicron/tests/test_condor.py
@@ -22,11 +22,7 @@
 import sys
 import os.path
 import tempfile
-
-try:
-    from unittest import mock
-except ImportError:  # python < 3
-    import mock
+from unittest import mock
 
 import pytest
 

--- a/omicron/tests/test_const.py
+++ b/omicron/tests/test_const.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) Duncan Macleod (2019)
+#
+# This file is part of PyOmicron.
+#
+# PyOmicron is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# PyOmicron is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with PyOmicron.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for omicron.const
+"""
+
+import os
+from importlib import reload
+from unittest import mock
+
+import pytest
+
+from .. import const
+
+
+@pytest.mark.parametrize("fqdn, ifo", [
+    ("ldas-grid.ligo-wa.caltech.edu", "H1"),
+    ("k1sum0.kagra", "K1"),
+    ("test.localhost", None)
+])
+@mock.patch("socket.getfqdn")
+def test_ifo(getfqdn, fqdn, ifo):
+    getfqdn.return_value = fqdn
+    reload(const)
+    assert const.IFO == ifo
+    assert const.ifo == (ifo.lower() if ifo else None)
+
+
+def test_omicron_vars():
+    assert str(const.OMICRON_BASE) == os.path.join(
+        os.environ["HOME"],
+        "omicron",
+    )

--- a/omicron/tests/test_parameters.py
+++ b/omicron/tests/test_parameters.py
@@ -21,10 +21,7 @@
 
 import os
 import tempfile
-try:
-    from configparser import ConfigParser
-except ImportError:  # python < 3
-    from ConfigParser import ConfigParser
+from configparser import ConfigParser
 
 import pytest
 

--- a/omicron/tests/test_segments.py
+++ b/omicron/tests/test_segments.py
@@ -21,12 +21,8 @@
 
 import tempfile
 from copy import deepcopy
-try:
-    from unittest import mock
-    from io import StringIO
-except ImportError:  # python < 3
-    from StringIO import StringIO
-    import mock
+from io import StringIO
+from unittest import mock
 
 import pytest
 

--- a/omicron/tests/utils.py
+++ b/omicron/tests/utils.py
@@ -20,8 +20,8 @@
 """
 
 import sys
-from six.moves import StringIO
 from contextlib import contextmanager
+from io import StringIO
 
 
 @contextmanager


### PR DESCRIPTION
This PR updates `omicron.const` to use regular expressions to match the FQDN of the host to an IFO prefix.

I also added a regex for KAGRA (`'K1'`), and some unit tests.