### PR TITLE
Cast map() to tuple or list where necessary

### DIFF
--- a/bin/omicron-process
+++ b/bin/omicron-process
@@ -342,7 +342,7 @@ logger.debug("overlap = %s" % overlap)
 padding = int(overlap / 2)
 logger.debug("padding = %s" % padding)
 try:
-    frange = map(float, cp.get(group, 'frequency-range').split())
+    frange = tuple(map(float, cp.get(group, 'frequency-range').split()))
 except configparser.NoOptionError as e:
     try:
         flow = cp.getfloat(group, 'flow')
@@ -372,7 +372,7 @@ except configparser.NoOptionError:
     statechannel = None
 else:
     try:
-        statebits = map(float, cp.get(group, 'state-bits').split(','))
+        statebits = list(map(float, cp.get(group, 'state-bits').split(',')))
     except configparser.NoOptionError:
         statebits = [0]
     try:
@@ -414,7 +414,7 @@ if statechannel or stateflag:
         try:
             p = int(statepad)
         except ValueError:
-            statepad = map(float, statepad.split(',', 1))
+            statepad = tuple(map(float, statepad.split(',', 1)))
         else:
             statepad = (p, p)
     logger.debug("State padding: %s" % str(statepad))

--- a/bin/omicron-status
+++ b/bin/omicron-status
@@ -193,7 +193,7 @@ if end == NOW:
 
 if args.state_flag:
     stateflag = args.state_flag
-    statepad = map(float, args.state_pad.split(','))
+    statepad = tuple(map(float, args.state_pad.split(',')))
 else:
     try:
         stateflag = cp.get(group, 'state-flag')
@@ -201,7 +201,7 @@ else:
         stateflag = None
     else:
         try:
-            statepad = map(float, cp.get(group, 'state-padding').split(','))
+            statepad = tuple(map(float, cp.get(group, 'state-padding').split(',')))
         except configparser.NoOptionError:
             statepad = (0, 0)
 if stateflag:

--- a/omicron/segments.py
+++ b/omicron/segments.py
@@ -155,7 +155,7 @@ def get_state_segments(channel, frametype, start, end, bits=[0], nproc=1,
         elif channel.endswith('GDS-CALIB_STATE_VECTOR'):
             io_kw['type'] = 'proc'
 
-    bits = map(str, bits)
+    bits = list(map(str, bits))
     # FIXME: need to read from cache with single segment but doesn't match
     # [start, end)
 


### PR DESCRIPTION
This PR fixes some failures on python3 where `map()` was not cast to `tuple` or `list` before being indexed.