### PR TITLE
Simplified omicron.condor.dag_is_running function

### DIFF
--- a/omicron/condor.py
+++ b/omicron/condor.py
@@ -451,16 +451,7 @@ def dag_is_running(dagfile, schedd=None):
         if multiple matching condor processes are found, or the matching
         single process is not in a good state
     """
-    if Path("{}.lock".format(dagfile)).is_file():
-        return True
-    userlog = "{}.dagman.log".format(dagfile)
-    try:
-        find_job(UserLog=userlog, schedd=schedd)
-    except RuntimeError as e:
-        if str(e).startswith('No jobs found'):
-            return False
-        raise
-    return True
+    return Path(dagfile).with_suffix(".dag.lock").is_file()
 
 
 def get_job_status(job, schedd=None):

--- a/omicron/tests/test_condor.py
+++ b/omicron/tests/test_condor.py
@@ -107,20 +107,10 @@ def test_get_job_status():
     assert condor.get_job_status(1) == 4
 
 
-@mock.patch('pathlib.Path.is_file')
+@mock.patch('pathlib.Path.is_file', side_effect=(False, True))
 def test_dag_is_running(isfile):
-    isfile.return_value = False
     assert not condor.dag_is_running('test.dag')
-
-    isfile.return_value = True
     assert condor.dag_is_running('test.dag')
-
-    isfile.return_value = False
-    schedd_ = mock_schedd_factory(
-        [{'UserLog': 'test.dag.dagman.log'}])
-    with mock.patch('htcondor.Schedd', schedd_):
-        assert condor.dag_is_running('test.dag')
-        assert not condor.dag_is_running('test2.dag')
 
 
 def test_find_rescue_dag():


### PR DESCRIPTION
This PR simplifies the `dag_is_running` function to just check for existence of the `.dag.lock` file.