### PR TITLE
Removed unnecessary __future__ imports

### DIFF
--- a/bin/omicron-print
+++ b/bin/omicron-print
@@ -19,8 +19,6 @@
 """Print Omicron events or file locations
 """
 
-from __future__ import print_function
-
 import argparse
 import operator
 import sys

--- a/bin/omicron-process
+++ b/bin/omicron-process
@@ -59,8 +59,6 @@ The output of `omicron-process` is a Directed Acyclic Graph (DAG) that is
 
 """
 
-from __future__ import print_function
-
 import argparse
 import configparser
 import os


### PR DESCRIPTION
This PR removes all `from __future__` imports; since we require python>=3.6, we don't need them.