### PR TITLE
Use custom astropy config directory for omicron-process workflows

### DIFF
--- a/bin/omicron-process
+++ b/bin/omicron-process
@@ -692,6 +692,10 @@ for seg in trigsegs:
     logger.info("    %d %d " % seg + "[%d]" % abs(seg))
 logger.info("Duration = %d seconds" % abs(trigsegs))
 
+# -- config omicron config directory ------------------------------------------
+
+tempfiles.append(utils.astropy_config_path(rundir))
+
 # -- make parameters files then generate the DAG ------------------------------
 
 fileformats = oconfig.output_formats()

--- a/omicron/condor.py
+++ b/omicron/condor.py
@@ -19,6 +19,7 @@
 """Condor interaction utilities
 """
 
+import os
 import os.path
 import re
 import time
@@ -100,7 +101,7 @@ def submit_dag(dagfile, *arguments, **options):
         cmd.extend([opt, val])
     cmd.append(dagfile)
     print("$ %s" % ' '.join(cmd))
-    out = check_output(cmd).decode('utf-8')
+    out = check_output(cmd, env=os.environ).decode('utf-8')
     print(out)
     try:
         return int(re_dagman_cluster.search(out).group())

--- a/omicron/tests/test_utils.py
+++ b/omicron/tests/test_utils.py
@@ -20,6 +20,7 @@
 """
 
 import os
+from unittest import mock
 
 from .. import utils
 
@@ -41,3 +42,11 @@ def test_get_omicron_version():
     assert utils.get_omicron_version() == testv
     assert utils.get_omicron_version() > 'v1r2'
     assert utils.get_omicron_version() < 'v2r2'
+
+
+@mock.patch.dict(os.environ)
+def test_astropy_config_path(tmp_path):
+    confpath = utils.astropy_config_path(tmp_path, update_environ=True)
+    assert confpath == tmp_path / ".config"
+    assert os.environ["XDG_CONFIG_HOME"] == str(confpath)
+    assert (confpath / "astropy").is_dir()

--- a/omicron/tests/test_utils.py
+++ b/omicron/tests/test_utils.py
@@ -44,9 +44,15 @@ def test_get_omicron_version():
     assert utils.get_omicron_version() < 'v2r2'
 
 
-@mock.patch.dict(os.environ)
+@mock.patch.dict(os.environ, clear=True)
 def test_astropy_config_path(tmp_path):
     confpath = utils.astropy_config_path(tmp_path, update_environ=True)
     assert confpath == tmp_path / ".config"
     assert os.environ["XDG_CONFIG_HOME"] == str(confpath)
     assert (confpath / "astropy").is_dir()
+
+
+@mock.patch.dict(os.environ, clear=True)
+def test_astropy_config_path_no_environ(tmp_path):
+    confpath = utils.astropy_config_path(tmp_path, update_environ=False)
+    assert "XDG_CONFIG_HOME" not in os.environ

--- a/omicron/utils.py
+++ b/omicron/utils.py
@@ -19,8 +19,8 @@
 """Miscellaneous utilities
 """
 
-import re
 import os
+import re
 from distutils.version import StrictVersion
 from pathlib import Path
 
@@ -113,3 +113,15 @@ def get_omicron_version(executable=None):
                       'please specify the executable path',)
             raise
     return OmicronVersion(vstr)
+
+
+def astropy_config_path(parent, update_environ=True):
+    """Create and return a directory for a temporary astropy config path
+    """
+    parent = Path(parent)
+    astropath = parent / ".config" / "astropy"
+    astropath.mkdir(exist_ok=True, parents=True)
+    confpath = astropath.parent
+    if update_environ:
+        os.environ["XDG_CONFIG_HOME"] = str(confpath)
+    return confpath

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ install_requires = [
     'six',
 ]
 tests_require = [
-    'pytest',
+    'pytest >= 3.9',
 ]
 if {'test'}.intersection(sys.argv):
     setup_requires.extend([


### PR DESCRIPTION
This PR implements a few things in order to use a custom, temporary directory for the astropy configuration files. This should hopefully mitigate the sort of issues that @alurban and I have seen when running in production for LIGO.

Summary of changes:

- new `omicron.utils.astropy_config_path` function to create temporary `XDG_CONFIG_HOME`,
- `omicron.condor.submit_dag` now passes `os.environ` to the subprocess,
- `omicron-process` calls `astropy_config_path` to build a custom, temporary astropy configuration path, deleting after the workflow completes (successfully).