### PR TITLE
Remove conda cache in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: generic
 
-env:
-  global:
-    - CONDA_PKGS_DIRS="${HOME}/.cache/conda/pkgs"
-
 matrix:
   fast_finish: true
 
@@ -58,9 +54,6 @@ after_success:
   - python -m codecov --flags $(uname) python${PYTHON_VERSION/./}
 
 before_cache:
-  - conda clean --quiet --yes --all
   - rm -f $HOME/.cache/pip/log/debug.log
 cache:
   pip: true
-  directories:
-    - ${HOME}/.cache/conda/pkgs


### PR DESCRIPTION
This PR removes the caching of conda packages in the travis builds, it seems to just slow things down. ATOW this is `WIP` since I'm not sure my statement is actually true.