### PR TITLE
Migrate omicron support to >=2.3.12

### DIFF
--- a/bin/omicron-process
+++ b/bin/omicron-process
@@ -83,6 +83,11 @@ __author__ = 'Duncan Macleod <duncan.macleod@ligo.org>'
 
 logger = log.Logger('omicron-process')
 
+try:
+    OMICRON_PATH = str(utils.find_omicron())
+except RuntimeError:
+    OMICRON_PATH = None
+
 DAG_TAG = "omicron"
 
 
@@ -172,7 +177,7 @@ mode.add_argument('--no-submit', action='store_true', default=False,
 condorg.add_argument('--universe', default='vanilla',
                      choices=['vanilla', 'local'],
                      help='condor universe, default: %(default)s')
-condorg.add_argument('--executable', default=find_executable('omicron.exe'),
+condorg.add_argument('--executable', default=OMICRON_PATH,
                      help='omicron executable, default: %(default)s')
 condorg.add_argument('--condor-retry', type=int, default=2,
                      help='number of times to retry each job if failed, '
@@ -241,7 +246,7 @@ if args.ifo is None:
     parser.error("Cannot determine IFO prefix from sytem, "
                  "please pass --ifo on the command line")
 if args.executable is None:
-    parser.error("Cannot find omicron.exe on path, please pass "
+    parser.error("Cannot find omicron on path, please pass "
                  "--executable on the command line")
 
 # validate processing options
@@ -297,12 +302,6 @@ omicronv = utils.get_omicron_version(args.executable)
 const.OMICRON_VERSION = str(omicronv)
 os.environ.setdefault('OMICRON_VERSION', str(omicronv))
 logger.debug('Omicron version: %s' % omicronv)
-
-# XXX reset const variables for Omicron v2r2 XXX
-# this can be removed when v2r2 is the stable release
-if omicronv >= 'v2r2':
-    const.OMICRON_FILETAG = 'OMICRON'
-
 
 # -- parse configuration file and get parameters ------------------------------
 
@@ -933,10 +932,9 @@ for s, e in segs:
                 if newdag:
                     script.chmod(0o755)
 
-# set 'strict' option for newer versions of Omicron
+# set 'strict' option for Omicron
 # this is done after the nodes are written so that 'strict' is last in the call
-if omicronv >= 'v2r2':
-    ojob.add_arg('strict')
+ojob.add_arg('strict')
 
 # do all archiving last, once all post-processing has completed
 if args.archive:

--- a/bin/omicron-process
+++ b/bin/omicron-process
@@ -194,8 +194,8 @@ condorg.add_argument('--submit-rescue-dag', type=int, default=0,
                           'rescue DAG, default: %(default)s')
 condorg.add_argument('-c', '--condor-command', action='append', type=str,
                      default=[], metavar="\"key=value\"",
-                     help="Extra condor submit commands to add to "
-                          "gw_summary submit file. Can be given "
+                     help="Extra commands to add to the "
+                          "HTCondor submit files, can be given "
                           "multiple times")
 condorg.add_argument('-d', '--dagman-option', action='append', type=str,
                      default=['force'], metavar="\"opt | opt=value\"",

--- a/omicron/const.py
+++ b/omicron/const.py
@@ -59,10 +59,7 @@ OMICRON_PROD = OMICRON_BASE / "online"
 # archive storage directory
 OMICRON_ARCHIVE = HOME / "triggers"
 # tag Omicron itself places on XML files
-OMICRON_FILETAG = 'Omicron'
-
-# omicron production version
-OMICRON_VERSION = 'v2r1'
+OMICRON_FILETAG = 'OMICRON'
 
 # omicron channel files
 if ifo is not None:

--- a/omicron/parameters.py
+++ b/omicron/parameters.py
@@ -46,23 +46,18 @@ class OmicronParameters(configparser.ConfigParser):
     OMICRON_DEFAULTS[None] = {
         'PARAMETER': {
             'CLUSTERING': 'TIME',
+            'FFTPLAN': 'FFTW_ESTIMATE',
             'TRIGGERRATEMAX': 100000,
         },
         'OUTPUT': {
             'DIRECTORY': os.path.curdir,
             'PRODUCTS': 'triggers',
             'VERBOSITY': 1,
-            'FORMAT': 'rootxml',
+            'FORMAT': 'root xml hdf5',
             'NTRIGGERMAX': 1e7,
         },
         'DATA': {
         },
-    }
-    OMICRON_DEFAULTS['v2r2'] = {
-        'PARAMETER': {'FFTPLAN': 'FFTW_ESTIMATE'},
-    }
-    OMICRON_DEFAULTS['v2r3'] = {
-        'OUTPUT': {'FORMAT': 'root xml hdf5'},
     }
 
     def __init__(self, version=None, defaults=dict(), **kwargs):
@@ -254,26 +249,25 @@ class OmicronParameters(configparser.ConfigParser):
                 else:
                     new.set(group, omikey, val)
 
-        # get parameters
-        if new.version >= 'v2r2':
-            # rename 'CHUNKDURATION' -> 'PSDLENGTH'
-            try:
-                psdlength = new.get('PARAMETER', 'CHUNKDURATION')
-            except configparser.NoOptionError:
-                pass
-            else:
-                new.remove_option('PARAMETER', 'CHUNKDURATION')
-                new.set('PARAMETER', 'PSDLENGTH', psdlength)
-            # combine 'SEGMENTDURATION' and 'OVERLAPDURATION' into 'TIMING'
-            try:
-                timing = (new.get('PARAMETER', 'SEGMENTDURATION'),
-                          new.get('PARAMETER', 'OVERLAPDURATION'))
-            except configparser.NoOptionError:
-                pass
-            else:
-                new.remove_option('PARAMETER', 'SEGMENTDURATION')
-                new.remove_option('PARAMETER', 'OVERLAPDURATION')
-                new.set('PARAMETER', 'TIMING', '%s %s' % timing)
+        # -- get parameters
+        # rename 'CHUNKDURATION' -> 'PSDLENGTH'
+        try:
+            psdlength = new.get('PARAMETER', 'CHUNKDURATION')
+        except configparser.NoOptionError:
+            pass
+        else:
+            new.remove_option('PARAMETER', 'CHUNKDURATION')
+            new.set('PARAMETER', 'PSDLENGTH', psdlength)
+        # combine 'SEGMENTDURATION' and 'OVERLAPDURATION' into 'TIMING'
+        try:
+            timing = (new.get('PARAMETER', 'SEGMENTDURATION'),
+                      new.get('PARAMETER', 'OVERLAPDURATION'))
+        except configparser.NoOptionError:
+            pass
+        else:
+            new.remove_option('PARAMETER', 'SEGMENTDURATION')
+            new.remove_option('PARAMETER', 'OVERLAPDURATION')
+            new.set('PARAMETER', 'TIMING', '%s %s' % timing)
 
         return new
 
@@ -307,13 +301,8 @@ class OmicronParameters(configparser.ConfigParser):
             frange = self.getfloats('PARAMETER', 'FREQUENCYRANGE')
         except configparser.NoOptionError:
             frange = None
-        if self.version >= 'v2r2':
-            chunk = self.getfloat('PARAMETER', 'PSDLENGTH')
-            segment, overlap = self.getfloats('PARAMETER', 'TIMING')
-        else:
-            chunk = self.getfloat('PARAMETER', 'CHUNKDURATION')
-            segment = self.getfloat('PARAMETER', 'SEGMENTDURATION')
-            overlap = self.getfloat('PARAMETER', 'OVERLAPDURATION')
+        chunk = self.getfloat('PARAMETER', 'PSDLENGTH')
+        segment, overlap = self.getfloats('PARAMETER', 'TIMING')
 
         # check parameters are valid
         assert segment <= chunk, (
@@ -350,14 +339,8 @@ class OmicronParameters(configparser.ConfigParser):
         """Prints the list of processing segments for a given data segment
         """
         # get parameters
-        if self.version >= 'v2r2':
-            segment, overlap = self.getfloats('PARAMETER', 'TIMING')
-            fileduration = segment - overlap
-        else:
-            chunk = self.getfloat('PARAMETER', 'CHUNKDURATION')
-            segment = self.getfloat('PARAMETER', 'SEGMENTDURATION')
-            overlap = self.getfloat('PARAMETER', 'OVERLAPDURATION')
-            fileduration = chunk - overlap
+        segment, overlap = self.getfloats('PARAMETER', 'TIMING')
+        fileduration = segment - overlap
         filesegment = segment - overlap
         padding = overlap / 2.
 
@@ -367,15 +350,7 @@ class OmicronParameters(configparser.ConfigParser):
         segments = SegmentList()
         while t < stop:
             e = min(t + fileduration, stop)
-            seg = Segment(t, e)
-            if filesegment < abs(seg) < fileduration:
-                remaining = abs(seg)
-                nseg = remaining // filesegment * filesegment
-                segments.append(Segment(t, t+nseg))
-                if nseg != remaining:
-                    segments.append(Segment(t+nseg, t+remaining))
-            else:
-                segments.append(seg)
+            segments.append(Segment(t, e))
             t = e
         return segments
 
@@ -406,12 +381,8 @@ class OmicronParameters(configparser.ConfigParser):
             a single segment under condor
         """
         # get parameters
-        if self.version >= 'v2r2':
-            chunk = self.getfloat('PARAMETER', 'PSDLENGTH')
-            _, overlap = self.getfloats('PARAMETER', 'TIMING')
-        else:
-            chunk = self.getfloat('PARAMETER', 'CHUNKDURATION')
-            overlap = self.getfloat('PARAMETER', 'OVERLAPDURATION')
+        chunk = self.getfloat('PARAMETER', 'PSDLENGTH')
+        overlap = self.getfloats('PARAMETER', 'TIMING')[1]
 
         # single small segment
         if end - start <= chunk * 2:

--- a/omicron/parameters.py
+++ b/omicron/parameters.py
@@ -341,7 +341,6 @@ class OmicronParameters(configparser.ConfigParser):
         # get parameters
         segment, overlap = self.getfloats('PARAMETER', 'TIMING')
         fileduration = segment - overlap
-        filesegment = segment - overlap
         padding = overlap / 2.
 
         # build list of file segments

--- a/omicron/tests/test_parameters.py
+++ b/omicron/tests/test_parameters.py
@@ -42,7 +42,7 @@ def create(*args, **kwargs):
 
 @pytest.fixture
 def pars():
-    return create(version='v2r2')
+    return create(version='2.3.12')
 
 
 def test_validate_parameters(pars):
@@ -189,6 +189,7 @@ def test_distribute_segments(pars):
 
 def test_output_files(pars):
     pars.set('PARAMETER', 'TIMING', '64 4')
+    pars.set('OUTPUT', 'FORMAT', 'root xml')
     pars.set('DATA', 'CHANNELS', 'X1:TEST-CHANNEL')
     assert pars.output_files(0, 100) == {
         'X1:TEST-CHANNEL': {

--- a/omicron/utils.py
+++ b/omicron/utils.py
@@ -21,6 +21,9 @@
 
 import os
 import re
+import subprocess
+import sys
+from distutils.spawn import find_executable
 from distutils.version import StrictVersion
 from pathlib import Path
 
@@ -45,41 +48,33 @@ def get_output_path(args):
     return args.output_dir.resolve(strict=False)
 
 
-# -- version comparison utilities
+def find_omicron():
+    """Find the omicron executable in the environment
 
-class OmicronVersion(StrictVersion):
-    version_re = re.compile(r'^v(\d+)r(\d+) (p(\d+))? ([ab](\d+))?$',
-                            re.VERBOSE)
+    Either via `PATH` or relative to the current python interpreter
 
-    def parse(self, vstring):
-        match = self.version_re.match(vstring)
-        if not match:
-            raise ValueError("invalid version number '%s'" % vstring)
+    Returns
+    -------
+    path : `pathlib.Path`
+        the path of the omicron executable
 
-        (major, minor, patch, prerelease, prerelease_num) = \
-            match.group(1, 2, 4, 5, 6)
-
-        if patch:
-            self.version = tuple(map(int, [major, minor, patch]))
-        else:
-            self.version = tuple(map(int, [major, minor])) + (None,)
-
-        if prerelease:
-            self.prerelease = (prerelease[0], int(prerelease_num))
-        else:
-            self.prerelease = None
-
-    def __str__(self):
-        if self.version[2] is None:
-            return 'v%sr%s' % (self.version[0], self.version[1])
-        else:
-            return 'v%sr%sp%s' % (self.version[0], self.version[1],
-                                  self.version[2])
-
-    def _cmp(self, other):
-        if isinstance(other, str):
-            other = OmicronVersion(other)
-        return StrictVersion._cmp(self, other)
+    Raises
+    ------
+    RuntimeError
+        if omicron cannot be found, or is not executable
+    """
+    exe = find_executable(
+        "omicron",
+        path=os.pathsep.join((
+            os.getenv("PATH", ""),
+            str(Path(sys.executable).parent),
+        )),
+    )
+    if not exe or not os.access(exe, os.X_OK):
+        raise RuntimeError(
+            "cannot locate omicron in environment or is not executable"
+        )
+    return Path(exe).resolve()
 
 
 def get_omicron_version(executable=None):
@@ -97,22 +92,21 @@ def get_omicron_version(executable=None):
 
     Examples
     --------
-    >>> get_omicron_version("/home/detchar/opt/virgosoft/Omicron/v2r1/Linux-x86_64/omicron.exe")
-    'v2r1'
+    >>> get_omicron_version()
+    '2.1.0'
     """  # noqa: E501
-    if executable:
-        executable = Path(executable).resolve()
-        vstr = executable.parent.parent.name
-    elif os.getenv('OMICRON_VERSION'):
-        vstr = os.environ['OMICRON_VERSION']
-    else:
-        try:
-            vstr = Path(os.environ['OMICRONROOT']).name
-        except KeyError as e:
-            e.args = ('Cannot parse Omicron version from environment, '
-                      'please specify the executable path',)
-            raise
-    return OmicronVersion(vstr)
+    executable = executable or find_omicron()
+    try:
+        return StrictVersion(
+            subprocess.check_output([
+                executable,
+                "version",
+            ]).decode("utf-8").rsplit(maxsplit=1)[-1],
+        )
+    except subprocess.CalledProcessError:
+        raise RuntimeError(
+            "failed to determine omicron version from executable"
+        )
 
 
 def astropy_config_path(parent, update_environ=True):

--- a/omicron/utils.py
+++ b/omicron/utils.py
@@ -20,7 +20,6 @@
 """
 
 import os
-import re
 import subprocess
 import sys
 from distutils.spawn import find_executable

--- a/requirements.yml
+++ b/requirements.yml
@@ -15,6 +15,7 @@ dependencies:
   - markuppy
   - numpy
   - omicron >=2.3.12
+  - pycondor
   - python
   - python-ldas-tools-framecpp
   - python-ligo-lw >=1.4.0

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ install_requires = [
     'lscsoft-glue >= 1.60.0',
     'MarkupPy',
     'numpy',
+    'pycondor',
     'python-ligo-lw >= 1.4.0',
     'six',
 ]


### PR DESCRIPTION
This PR upgrades the `omicron` requirement to 2.3.12 (the first conda-compatible release) and removes support for all older versions, allowing for a cleanup of some legacy-support code.

The following was tested on the LDAS computing center at Caltech to verify:

```shell
omicron-process GW -f ~detchar/omicron/online/l1-channels.ini --gps 1262995218 $((1262995218+600)) --ifo L1 --output-dir ~/tmp/pyomicron-test2 -v --condor-accounting-group ligo.dev.o3.detchar.transient.omicron --archive --condor-command "request_memory=4096" -v
```