### PR TITLE
Add support for python3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ matrix:
       env: PYTHON_VERSION="3.6"
     - os: linux
       env: PYTHON_VERSION="3.7"
+    - os: linux
+      env: PYTHON_VERSION="3.8"
     # -- disabled until we can install htcondor on osx
     #- os: osx
     #  env: PYTHON_VERSION="3.6"

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Scientific/Engineering',
         'Topic :: Scientific/Engineering :: Astronomy',
         'Topic :: Scientific/Engineering :: Physics',


### PR DESCRIPTION
This PR adds a travis job for python3.8, and the equivalent PyPI classifier declaring python3.8 support.