### PR TITLE
Update the name of Virgo's nominal lock flag

### DIFF
--- a/omicron/segments.py
+++ b/omicron/segments.py
@@ -89,7 +89,7 @@ STATE_CHANNEL = {
         "L1_HOFT_C00",
     ),
     # Virgo
-    "V1:ITF_LOCKED:1": (
+    "V1:ITF_NOMINAL_LOCK:1": (
         "V1:DQ_ANALYSIS_STATE_VECTOR",
         [11],
         "V1Online",


### PR DESCRIPTION
This PR updates the name of Virgo's data-quality flag determining a nominal lock state.

cc @duncanmmacleod 