### PR TITLE
Install the correct python version up front in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,8 @@ before_install:
 
 install:
   # create a conda environment including our requirements
-  - travis_retry conda env create --quiet --name pyomicron --file requirements.yml
+  - travis_retry conda create --name pyomicron python=${PYTHON_VERSION}
+  - travis_retry conda env update --quiet --name pyomicron --file requirements.yml
   - travis_retry conda activate pyomicron
   # install testing dependencies with conda
   - travis_retry conda install --quiet --yes --update-deps --name pyomicron


### PR DESCRIPTION
This PR addresses an issue in the CI where the desired python version is completely ignored and all jobs use the latest version.