### PR TITLE
Address issue #43, bad error message(s) for missing arguments

### DIFF
--- a/omicron/cli/status.py
+++ b/omicron/cli/status.py
@@ -78,7 +78,7 @@ def create_parser():
     parser.add_argument(
         '-f',
         '--config-file', default=const.OMICRON_CHANNELS_FILE,
-        help='path to configuration file',
+        help='path to a channel list configuration file',
     )
     parser.add_argument(
         '-i',

--- a/omicron/cli/status.py
+++ b/omicron/cli/status.py
@@ -77,7 +77,7 @@ def create_parser():
     )
     parser.add_argument(
         '-f',
-        '--config-file',
+        '--config-file', default=const.OMICRON_CHANNELS_FILE,
         help='path to configuration file',
     )
     parser.add_argument(
@@ -271,13 +271,20 @@ def main(args=None):
     )
 
     # -- parse configuration file and get parameters --------------------------
-
+    ifo = args.ifo
+    if ifo is None:
+        raise ValueError('IFO is unknown.')
+    if args.config_file is None:
+        config_file = const.OMICRON_PROD / f"{ifo}-channels.ini"
+    else:
+        config_file = args.config_file
+    config_file = Path(config_file)
+    if not config_file.exists():
+        raise IOError(f'Configuration file does not exist: {str(config_file.absolute())}')
     cp = configparser.ConfigParser()
-    ok = cp.read(args.config_file)
-    if args.config_file not in ok:
-        raise IOError(
-            "Failed to read configuration file %r" % args.config_file,
-        )
+    ok = cp.read(config_file)
+    if str(config_file) not in ok:
+        raise IOError(f"Failed to read configuration file {str(config_file.absolute())}")
     logger.info("Configuration read")
 
     # validate

--- a/omicron/const.py
+++ b/omicron/const.py
@@ -63,8 +63,8 @@ OMICRON_FILETAG = 'OMICRON'
 
 # omicron channel files
 if ifo is not None:
-    OMICRON_GROUP_FILE = OMICRON_PROD / "{}-groups.txt".format(ifo)
-    OMICRON_CHANNELS_FILE = OMICRON_PROD, "{}-channels.txt".format(ifo)
+    OMICRON_GROUP_FILE = OMICRON_PROD / f"{ifo}-groups.txt"
+    OMICRON_CHANNELS_FILE = OMICRON_PROD / f"{ifo}-channels.ini"
 else:
     OMICRON_GROUP_FILE = None
     OMICRON_CHANNELS_FILE = None


### PR DESCRIPTION
Old issue about poor error message when we can not determine defaults for IFO and omicron configuration file.

We do not need to create a new release right away for such a small fix