### PR TITLE
Merge day boundary

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,6 +46,7 @@ Documentation
 
    workflow/index
    configuration/index
+   workflow/simulations
 
 **Utilities**
 

--- a/docs/workflow/simulations.rst
+++ b/docs/workflow/simulations.rst
@@ -1,0 +1,118 @@
+How to run omicron on simulated data
+====================================
+
+The pyomicron system can be used to process data in frames outside the usual
+process. That is when the data frames are not in the datafind
+system and data quality segments and Guardian states do not apply.
+
+The steps are:
+
+* Create a configuration file
+* Create a frame cache
+* Specify to not use the data quality segments
+
+Below is a sample Python program which creates an example frame file
+with 200 seconds of gaussian noise and adds a few sine-gaussiasn glitches.
+It produces a frame file in /tmp.
+
+.. code-block::
+
+    from gwpy.timeseries import TimeSeries
+    from numpy.random import normal
+    from numpy import linspace
+    from scipy.signal import gausspulse
+    from gpstime import tconvert
+    from pathlib import Path
+
+    # Generate a TimeSeries containing Gaussian noise sampled at 4096 Hz,
+    # with several sine-Gaussian pulses (‘glitch’) at different frequencies:
+    strt = tconvert('9/1/2022')
+    fs = 4096
+    dur = 200
+    ndata = fs * dur
+    outdir = Path('/tmp')
+
+    # sine gaussian "glitches"
+    t = linspace(-1, 1, 2 * fs, endpoint=False)
+    sg = gausspulse(t, fc=250, retquad=False, retenv=False)
+    sg2 = gausspulse(t, fc=500, retquad=False, retenv=False)
+    sg3 = gausspulse(t, fc=750, retquad=False, retenv=False)
+
+    # add  several sets of glitches to the noise
+    data = normal(loc=1, size=ndata)  # Gaussian noise
+
+    for t in range(int(dur/4), int(3*dur/4), int(dur/10)):
+        data[fs*(t-1):fs*(t+1)] += sg * 12
+        data[fs*(t+6):fs*(t+8)] += sg2 * 10
+        data[fs*(t+13):fs*(t+15)] += sg3 * 8
+
+    ts = TimeSeries(data, t0=strt, sample_rate=fs, name='Z1:SIM-SINE_GAUSS',
+                    channel='Z1:SIM-SINE_GAUSS')
+    out_file = str(outdir / f'Z-Z1_SIM-{int(strt)}-{dur}.gwf')
+    ts.write(out_file)
+    print(f'Wrote {out_file}')
+
+Create a LAL format cache file such as sim.lcf:
+
+.. code-block::
+
+      file://localhost/tmp/Z-Z1_SIM-1346050818-200.gwf
+
+Create a pyomicron configuration file named sim.ini:
+
+.. code-block::
+
+    [SIM]
+    q-range = 3.3166 150
+    frequency-range = 4.0 2048.0
+    frametype = Z-Z1_SIM
+    sample-frequency = 4096
+    chunk-duration = 124
+    segment-duration = 64
+    overlap-duration = 4
+    mismatch-max = 0.2
+    snr-threshold = 6
+    channels = Z1:SIM-SINE_GAUSS
+
+We can now run pyomicron:
+
+.. code-block::
+
+    omicron-process --gps 1346050818 1346051018 --ifo Z1 --config-file ./sim.ini \
+        --output-dir ./run --no-segdb --cache-file ./sim.lcf -vvv --file-tag SIM SIM
+
+The results will be in the directory:
+
+.. code-block::
+
+    ./run/merge/Z1:SIM-SINE_GAUSS/
+
+One way to view them is to use ligolw_print. The results, formatted for readability:
+
+.. code-block::
+
+    ligolw_print -t sngl_burst -c 'peak_time' -c 'snr' -c 'peak_frequency' \
+        'run/merge/Z1:SIM-SINE_GAUSS/Z1-SIM_SINE_GAUSS_OMICRON-1346050820-196.xml.gz'
+
+    +------------+-----------+--------------+
+    | peak_time  | SNR       | Frequency    |
+    +============+===========+==============|
+    | 1346050868 | 37.1      | 236.4        |
+    | 1346050875 | 22.1      | 480.7        |
+    | 1346050882 | 15.2      | 771.3        |
+    | 1346050888 | 37.1      | 243.9        |
+    | 1346050894 | 21.4      | 459.1        |
+    | 1346050902 | 13.7      | 699.8        |
+    | 1346050908 | 36.5      | 266.1        |
+    | 1346050915 | 22.4      | 480.7        |
+    | 1346050922 | 13.9      | 771.3        |
+    | 1346050928 | 36.0      | 236.4        |
+    | 1346050935 | 22.1      | 480.6        |
+    | 1346050942 | 14.2      | 771.3        |
+    | 1346050948 | 38.7      | 243.9        |
+    | 1346050954 | 24.3      | 459.1        |
+    | 1346050962 | 15.0      | 699.7        |
+    +------------+-----------+--------------+
+
+
+

--- a/docs/workflow/simulations.rst
+++ b/docs/workflow/simulations.rst
@@ -15,7 +15,7 @@ Below is a sample Python program which creates an example frame file
 with 200 seconds of gaussian noise and adds a few sine-gaussiasn glitches.
 It produces a frame file in /tmp.
 
-.. code-block::
+.. code-block:: python
 
     from gwpy.timeseries import TimeSeries
     from numpy.random import normal

--- a/omicron/cli/merge_with_gaps.py
+++ b/omicron/cli/merge_with_gaps.py
@@ -270,7 +270,7 @@ def main():
             continue
 
         etime = stime + cdur
-        sday = int(stime/100000)
+        sday = int(stime / 100000)
         if start_time is None:
             # first file in this time interval
             start_time = stime
@@ -301,6 +301,9 @@ def main():
         else:
             error_cnt += 1
 
+    elap = time.time() - prog_start_time
+    logger.info('run time {:.1f} s'.format(elap))
+
     if error_cnt > 0:
         logger.error(f'{error_cnt} errors detected.')
         sys.exit(1)
@@ -308,9 +311,6 @@ def main():
         # STDOUT should have only the list of output files
         print(' '.join(outfiles))
         sys.exit(0)
-
-    elap = time.time() - prog_start_time
-    logger.info('run time {:.1f} s'.format(elap))
 
 
 if __name__ == "__main__":

--- a/omicron/cli/merge_with_gaps.py
+++ b/omicron/cli/merge_with_gaps.py
@@ -223,6 +223,7 @@ def main():
     logger.info(f'FILES: {len(args.infiles)} requested {len(infiles)} were found.')
     curfiles = list()
     start_time = None
+    start_day = None
     end_time = None
     name = None
     ext = None
@@ -269,24 +270,28 @@ def main():
             continue
 
         etime = stime + cdur
+        sday = int(stime/100000)
         if start_time is None:
             # first file in this time interval
             start_time = stime
+            start_day = sday
             end_time = etime
             curfiles.append(inpath)
-        elif stime == end_time:
-            # this file is contiguous with previous, so it can be concatenated
+        elif stime == end_time and sday == start_day:
+            # this file is contiguous with previous, and it is in the same "metric day"
+            # so it can be concatenated
             end_time = etime
             curfiles.append(inpath)
         else:
-            # break in continuity
+            # break in continuity or start of a new metric day
             outfile = do_merge(out_dir, curfiles, name, start_time, end_time, ext, args.no_gzip)
             if outfile:
                 outfiles.append(outfile)
             else:
                 error_cnt += 1
-
+            # reset for next merge
             start_time = stime
+            start_day = sday
             end_time = etime
             curfiles = [inpath]
     if curfiles:

--- a/omicron/cli/merge_with_gaps.py
+++ b/omicron/cli/merge_with_gaps.py
@@ -145,7 +145,7 @@ def valid_file(path, uint_bug):
             table = EventTable.read(path, path='/triggers')
         elif path.name.endswith('.xml.gz') or path.name.endswith('.xml'):
             if uint_bug:
-                sed_cmd = ['sed', '-i', '-e', 's/uint_8s/int_8u/g', str(path.absolute())]
+                sed_cmd = ['sed', '-i', '', '-e', 's/uint_8s/int_8u/g', str(path.absolute())]
                 subprocess.run(sed_cmd)
             table = EventTable.read(path, tablename='sngl_burst')
         elif path.name.endswith('.root'):

--- a/omicron/cli/process.py
+++ b/omicron/cli/process.py
@@ -865,6 +865,18 @@ def main(args=None):
         logger.warning("Not all state times are available in frames")
     segs = (cachesegs & segs).coalesce()
 
+    # Deal with segments that cross a metric day (100,000 boundary)
+    seg_tmp = SegmentList()
+    for seg in segs:
+        sday = int(seg[0] / 1e5)
+        eday = int(seg[1] / 1e5)
+        if sday == eday:
+            seg_tmp.append(seg)
+        else:
+            seg1 = Segment(seg[0], eday)
+            seg2 = Segment(eday, seg[1])
+            seg_tmp.append(seg1)
+            seg_tmp.append(seg2)
     # apply minimum duration requirement
     segs = type(segs)(s for s in segs if abs(s) >= segdur)
 

--- a/omicron/cli/process.py
+++ b/omicron/cli/process.py
@@ -59,6 +59,9 @@ The output of `omicron-process` is a Directed Acyclic Graph (DAG) that is
 
 """
 import time
+
+from gwpy.segments import SegmentList, Segment
+
 prog_start = time.time()
 import argparse
 import configparser
@@ -750,6 +753,13 @@ def main(args=None):
         segs = segments.query_state_segments(stateflag, datastart, dataend,
                                              pad=statepad)
         logger.info(f'Segment query took {time.time() - seg_qry_strt:.2f}s')
+
+    # Get segments from frame cache
+    elif args.cache_file:
+        cache = read_cache(str(args.cache_file))
+        cache_segs = segments.cache_segments(cache)
+        srch_span = SegmentList([Segment(datastart, dataend)])
+        segs = cache_segs & srch_span
 
     # get segments from frame availability
     else:


### PR DESCRIPTION
This addresses issue https://github.com/gwpy/pyomicron/issues/144 by not creating trigger files that cross a metric day boundary (100,000 seconds).

The problem is that searches for triggers (gwtrigfind like) are based in the metic day directory structure so if an analysis segment starts in one day and crosses into the next a search would not see triggers in the next but our overlap checks spot them.

There was also a snippet from PR #143 that did not make into that PR by mistake.
We found this one filling PEM gaps that ended up with one trigger file covering 68 hrs.