### PR TITLE
Improve formatting of segments for nagios from omicron-status

### DIFF
--- a/omicron/cli/status.py
+++ b/omicron/cli/status.py
@@ -31,7 +31,9 @@ import warnings
 from collections import OrderedDict
 from functools import reduce
 from getpass import getuser
+from os import linesep
 from pathlib import Path
+from textwrap import indent
 from time import sleep
 
 import htcondor
@@ -713,7 +715,16 @@ def main(args=None):
         jsonfp = outdir / "nagios-{}-{}.json".format(tag, group)
         status.append((tag, jsonfp))
         if chans:
-            gapstr = '\n'.join('%s: %s' % c for c in chans)
+            # format the segments nicely for Icinga 2
+            lines = []
+            for chan, ftsegs in chans:
+                lines.append(f"{chan}:")
+                for ft, segs in ftsegs.items():
+                    lines.extend((
+                        f"  {ft}:",
+                        indent(str(segs), "    "),
+                    ))
+            gapstr = linesep.join(lines)
             code = 1
             message = ("%s found in Omicron files for group %r\n%s"
                        % (tag.title(), group, gapstr))


### PR DESCRIPTION
This PR improves the formatting of `SegmentList` objects in nagios JSON reports generated by `omicron-status`.

The problem is, e.g. [here](https://ldas-jobs.ligo-la.caltech.edu/~detchar/omicron/nagios/PEM2/nagios-gaps-PEM2.json)), that standard representation of a `gwpy.segment.SegmentList` includes angle brackets (`<` and `>`) which the HTML renderer on dashboard.igwn.org can't handle, so the segment information is just lost.

The fix here is a more brute-force detailed formatting of the segments.