### PR TITLE
Fix typo in log omicron-process message

### DIFF
--- a/omicron/cli/process.py
+++ b/omicron/cli/process.py
@@ -797,7 +797,7 @@ def main(args=None):
                 pad=statepad,
             )
         else:
-            logger.debug(f'Using segdb for {statechannel}: {datastart}-{dataend}')
+            logger.debug(f'Using statevector for {statechannel}: {datastart}-{dataend}')
             segs = segments.get_state_segments(
                 statechannel,
                 stateft,


### PR DESCRIPTION
This PR fixes a trivial typo in a log message from `omicron-process` (it confused me for a few minutes).