### PR TITLE
Install pip2conda in its own environment in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,8 +69,6 @@ jobs:
         miniforge-variant: Mambaforge
         python-version: ${{ matrix.python-version }}
         use-mamba: true
-        # this is needed for caching to work properly:
-        use-only-tar-bz2: true
 
     - name: Conda info
       run: conda info --all
@@ -78,8 +76,8 @@ jobs:
     - name: Install dependencies
       run: |
         # parse requirements to install as much as possible with conda
-        mamba install --name base pip2conda
-        ${CONDA_PYTHON_EXE} -m pip2conda \
+        mamba create --name pip2conda pip2conda
+        mamba run --name pip2conda pip2conda \
             --all \
             --output environment.txt \
             --python-version ${{ matrix.python-version }}


### PR DESCRIPTION
This PR makes a tweak to the CI configuration to install `pip2conda` into its own environment, which allows using a newer version of Python than in the `base` environment.