### PR TITLE
Remove unused variable

### DIFF
--- a/omicron/tests/mock_htcondor.py
+++ b/omicron/tests/mock_htcondor.py
@@ -19,7 +19,6 @@ class Schedd(object):
                 break
             else:
                 x[a] = eval(b)
-        match = []
 
         def match(job):
             for key in x:


### PR DESCRIPTION
This PR removes an unused variable from the `mock_htcondor` module that was failing the lint check.