### PR TITLE
Remove support for Omicron txt output

### DIFF
--- a/docs/utilities/merge.rst
+++ b/docs/utilities/merge.rst
@@ -22,8 +22,6 @@ merge te contiguous trigger files:
 +------------+-----------+-------------------------------------------------+
 | ligolw     | ``.xml `` | ``ligolw_add`` and ``gzip``                     |
 +------------+-----------+-------------------------------------------------+
-| Text       | ``.txt `` | ``?``                                           |
-+------------+-----------+-------------------------------------------------+
 
 The ``omicron-root-merge`` executable is a thin wrapper on top of
 the :meth:`omicron.io.merge_root_files` method:

--- a/omicron/cli/process.py
+++ b/omicron/cli/process.py
@@ -1189,18 +1189,6 @@ def main(args=None):
 
                         rmfiles.append(xmlfiles)
 
-                    # add ASCII operations
-                    if 'txt' in fileformats:
-                        txtfiles = ' '.join(omicronfiles[c]['txt'])
-                        for f in omicronfiles[c]['txt']:
-                            ppnode.add_input_file(f)
-                        if args.archive:
-                            try:
-                                archivefiles[target].append(txtfiles)
-                            except KeyError:
-                                archivefiles[target] = [txtfiles]
-                            rmfiles.append(txtfiles)
-
                 ppnode.set_category('postprocessing')
                 ppnode.set_retry(str(args.condor_retry))
                 if not args.skip_omicron:

--- a/omicron/parameters.py
+++ b/omicron/parameters.py
@@ -403,7 +403,7 @@ class OmicronParameters(configparser.ConfigParser):
         return out
 
     def output_formats(self):
-        return [fmt for fmt in ('root', 'txt', 'xml', 'hdf5') if
+        return [fmt for fmt in ('root', 'xml', 'hdf5') if
                 fmt in self.get('OUTPUT', 'FORMAT')]
 
     def output_files(self, start, end, flatten=False):
@@ -431,7 +431,6 @@ class OmicronParameters(configparser.ConfigParser):
         fileformats = self.output_formats()
         extension = {
             'root': 'root',
-            'txt': 'txt',
             'xml': 'xml',
             'hdf5': 'h5',
         }


### PR DESCRIPTION
This PR closes #169 by removing support for configuring Omicron to produce, or postprocessing `.txt` output files.