### PR TITLE
Remove/replace all use of distutils module

### DIFF
--- a/omicron/cli/process.py
+++ b/omicron/cli/process.py
@@ -70,7 +70,6 @@ import re
 import sys
 import shutil
 import time
-from distutils.spawn import find_executable
 from getpass import getuser
 from pathlib import Path
 from subprocess import check_call
@@ -1028,7 +1027,7 @@ def main(args=None):
     ojob.add_condor_cmd('+OmicronProcess', f'"{group}"')
 
     # create post-processing jobs
-    ppjob = condor.OmicronProcessJob(args.universe, find_executable('bash'),
+    ppjob = condor.OmicronProcessJob(args.universe, shutil.which('bash'),
                                      subdir=condir, logdir=logdir,
                                      tag='post-processing', **condorcmds)
     ppjob.add_condor_cmd('+OmicronPostProcess', f'"{group}"')
@@ -1047,12 +1046,12 @@ def main(args=None):
     ppjob.add_short_opt('e', '')
     ppnodes = []
     prog_path = dict()
-    prog_path['omicron-merge'] = find_executable('omicron-merge-with-gaps')
-    prog_path['rootmerge'] = find_executable('omicron-root-merge')
-    prog_path['hdf5merge'] = find_executable('omicron-hdf5-merge')
-    prog_path['ligolw_add'] = find_executable('ligolw_add')
-    prog_path['gzip'] = find_executable('gzip')
-    prog_path['omicron_archive'] = find_executable('omicron-archive')
+    prog_path['omicron-merge'] = shutil.which('omicron-merge-with-gaps')
+    prog_path['rootmerge'] = shutil.which('omicron-root-merge')
+    prog_path['hdf5merge'] = shutil.which('omicron-hdf5-merge')
+    prog_path['ligolw_add'] = shutil.which('ligolw_add')
+    prog_path['gzip'] = shutil.which('gzip')
+    prog_path['omicron_archive'] = shutil.which('omicron-archive')
 
     goterr = list()
     for exe in prog_path.keys():
@@ -1068,7 +1067,7 @@ def main(args=None):
         rmjob = condor.OmicronProcessJob(
             args.universe, str(condir / "post-process-rm.sh"),
             subdir=condir, logdir=logdir, tag='post-processing-rm', **condorcmds)
-        rm = find_executable('rm')
+        rm = shutil.which('rm')
         rmjob.add_condor_cmd('+OmicronPostProcess', '"%s"' % group)
 
     if args.archive:
@@ -1112,7 +1111,7 @@ def main(args=None):
                     node.add_var_arg(str(subseg[1]))
                     node.add_file_arg(pf)
                     # we need to ignore errors in individual nodes
-                    node.set_post_script(find_executable('bash'))
+                    node.set_post_script(shutil.which('bash'))
                     node.add_post_script_arg('-c')
                     node.add_post_script_arg('exit 0')
 

--- a/omicron/condor.py
+++ b/omicron/condor.py
@@ -25,10 +25,10 @@ import re
 import time
 import warnings
 from datetime import datetime
-from distutils.spawn import find_executable
 from glob import glob
 from getpass import getuser
 from pathlib import Path
+from shutil import which
 from subprocess import (check_output, CalledProcessError)
 from time import sleep
 
@@ -96,7 +96,7 @@ def submit_dag(dagfile, *arguments, **options):
     subprocess.CalledProcessError
         if the call to `condor_submit_dag` fails for some reason
     """
-    cmd = [find_executable('condor_submit_dag')] + list(arguments)
+    cmd = [which("condor_submit_dag") or "condor_submit_dag"] + list(arguments)
     for opt, val in options.items():
         cmd.extend([opt, val])
     cmd.append(dagfile)

--- a/omicron/tests/test_condor.py
+++ b/omicron/tests/test_condor.py
@@ -45,7 +45,7 @@ def mock_schedd_factory(jobs):
 
 # -- tests --------------------------------------------------------------------
 
-@mock.patch('omicron.condor.find_executable', return_value=sys.executable)
+@mock.patch('shutil.which', return_value=sys.executable)
 @mock.patch('omicron.condor.check_output',
             return_value=b'1 job(s) submitted to cluster 12345')
 def test_submit_dag(shell, which):
@@ -53,7 +53,7 @@ def test_submit_dag(shell, which):
     assert dagid == 12345
 
 
-@mock.patch('omicron.condor.find_executable', return_value=sys.executable)
+@mock.patch('shutil.which', return_value=sys.executable)
 @mock.patch('omicron.condor.check_output',
             return_value=b'1 job(s) submitted to cluster 12345')
 def test_submit_dag_append(shell, which):
@@ -62,7 +62,7 @@ def test_submit_dag_append(shell, which):
                               '+OmicronDAGMan="GW"', 'test.dag'])
 
 
-@mock.patch('omicron.condor.find_executable', return_value=sys.executable)
+@mock.patch('shutil.which', return_value=sys.executable)
 @mock.patch('omicron.condor.check_output', return_value=b'Something else')
 def test_submit_dag_error(shell, which):
     with pytest.raises(AttributeError) as exc:

--- a/omicron/tests/test_utils.py
+++ b/omicron/tests/test_utils.py
@@ -25,18 +25,14 @@ import sys
 from pathlib import Path
 from unittest import mock
 
+from packaging.version import Version
+
 import pytest
 
 from .. import utils
 
-# distutils.spawn.find_executable works differently before python-3.7
-if sys.version_info < (3, 7):
-    ISFILE_SIDE_EFFECT = (False, False, True)
-else:
-    ISFILE_SIDE_EFFECT = (False, True)
 
-
-@mock.patch("os.path.isfile", side_effect=ISFILE_SIDE_EFFECT)
+@mock.patch("os.path.exists", return_value=True)
 @mock.patch("os.access", return_value=True)
 @mock.patch.dict("os.environ")
 def test_find_omicron_path(*mocks):
@@ -60,7 +56,7 @@ def test_find_omicron_error(_):
 @mock.patch("subprocess.check_output", return_value=b"Omicron 1.2.3")
 def test_get_omicron_version(mocker):
     v = utils.get_omicron_version("omicron")
-    assert v == "1.2.3"
+    assert v == Version("1.2.3")
 
 
 @mock.patch(

--- a/omicron/utils.py
+++ b/omicron/utils.py
@@ -22,9 +22,10 @@
 import os
 import subprocess
 import sys
-from distutils.spawn import find_executable
-from distutils.version import StrictVersion
 from pathlib import Path
+from shutil import which
+
+from packaging.version import Version
 
 from . import const
 
@@ -62,7 +63,7 @@ def find_omicron():
     RuntimeError
         if omicron cannot be found, or is not executable
     """
-    exe = find_executable(
+    exe = which(
         "omicron",
         path=os.pathsep.join((
             os.getenv("PATH", ""),
@@ -96,7 +97,7 @@ def get_omicron_version(executable=None):
     """  # noqa: E501
     executable = executable or find_omicron()
     try:
-        return StrictVersion(
+        return Version(
             subprocess.check_output([
                 executable,
                 "version",

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,6 +72,7 @@ install_requires =
 	lscsoft-glue >= 1.60.0
 	MarkupPy
 	numpy
+	packaging
 	pycondor
 	python-ligo-lw >= 1.4.0
 


### PR DESCRIPTION
This PR closes #171 by replacing all use of `distutils` with `shutil.which` and `packaging.version`.