### PR TITLE
Fix new lint from Python 3.12

### DIFF
--- a/omicron/cli/merge_with_gaps.py
+++ b/omicron/cli/merge_with_gaps.py
@@ -181,7 +181,7 @@ def valid_file(path, uint_bug):
             os.remove(path)
         else:
             ret = True
-        logger.debug(f'valid_file: {ret}  {path.name} ({ntrig}), took {time.time()-vf_strt:.2f}')
+        logger.debug(f'valid_file: {ret}  {path.name} ({ntrig}), took {time.time() - vf_strt:.2f}')
     return ret
 
 

--- a/omicron/cli/process.py
+++ b/omicron/cli/process.py
@@ -854,7 +854,7 @@ def main(args=None):
     # segment, or long enough to process safely)
     if truncate and abs(lastseg) < chunkdur * 2:
         logger.info(
-            "The final segment is too short, " f'Minimum length is {int(chunkdur*2)} '
+            "The final segment is too short, " f'Minimum length is {int(chunkdur * 2)} '
             "but ends at the limit of "
             "available data, presumably this is an active segment. It "
             "will be removed so that it can be processed properly later",
@@ -1447,7 +1447,7 @@ def main(args=None):
     clean_tempfiles(tempfiles)
 
     # and exit
-    logger.info(f"--- Processing complete. Elapsed: {time.time()-prog_start} seconds ----------------")
+    logger.info(f"--- Processing complete. Elapsed: {time.time() - prog_start} seconds ----------------")
 
 
 if __name__ == "__main__":

--- a/omicron/cli/status.py
+++ b/omicron/cli/status.py
@@ -862,4 +862,4 @@ def main(args=None):
 if __name__ == "__main__":
     main()
     if logger:
-        logger.info(f'Run time: {(time.time()-prog_start):.1f} seconds')
+        logger.info(f'Run time: {(time.time() - prog_start):.1f} seconds')

--- a/omicron/data.py
+++ b/omicron/data.py
@@ -190,7 +190,7 @@ def find_frames(obs, frametype, start, end, on_gaps='warn', **kwargs):
     if on_gaps != 'ignore':
         seglist = SegmentList(map(file_segment, cache)).coalesce()
         missing = (SegmentList([Segment(start, end)]) - seglist).coalesce()
-        msg = "Missing frames:\n{}".format('\n'.join(map(lambda s: f'[{s[0]}, {s[1]}) -> {s[1]-s[0]}s', missing)))
+        msg = "Missing frames:\n{}".format('\n'.join(map(lambda s: f'[{s[0]}, {s[1]}) -> {s[1] - s[0]}s', missing)))
         if missing and on_gaps == 'warn':
             warnings.warn(msg)
         elif missing:


### PR DESCRIPTION
This PR fixes new lint exposed by running `flake8` with Python 3.12.